### PR TITLE
doc: God forgive me for this.

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -7,7 +7,7 @@ module.exports = {
     themeConfig: {
 
         algolia: {
-            apiKey: process.env.ALGOLIA_API_KEY,
+            apiKey: '9fec1d1ad0cbbd09ecdbeb2a2f260948',
             indexName: 'toeapi'
         },
 


### PR DESCRIPTION
# `Context`
+ because VuePress gives out pre-rendered HTML files, it requires a lot of work to add secret keys
